### PR TITLE
Change the default Rect to a size

### DIFF
--- a/URL2PDF/PDFDownloader.m
+++ b/URL2PDF/PDFDownloader.m
@@ -60,7 +60,7 @@
     // Window
     
     NSWindow * window = [[NSWindow alloc]  
-                         initWithContentRect:NSMakeRect(0,0,1,1)                        
+                         initWithContentRect:NSMakeRect(0,0,1024,768)                        
                          styleMask:NSBorderlessWindowMask                         
                          backing:NSBackingStoreNonretained defer:NO];
     [window setContentView:webView];    


### PR DESCRIPTION
The current 1x1 Rect size is triggering responsive layouts on a lot of modern web pages, which is probably not the desired default behavior. This defaults the rect to a desktop-scale layout.
